### PR TITLE
Use extended port mapping format in compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,7 +115,11 @@ services:
     image: icinga/icinga2
     logging: *default-logging
     ports:
-      - 5665:5665
+      - target: 5665
+        published: 5665
+        protocol: tcp
+        mode: host
+        host_ip: "127.0.0.2"
     volumes:
       - icinga2:/data
       - ./icinga2.conf.d:/custom_data/custom.conf.d
@@ -148,7 +152,11 @@ services:
     logging: *default-logging
     image: icinga/icingaweb2
     ports:
-      - 8080:8080
+      - target: 8080
+        published: 8080
+        protocol: tcp
+        mode: host
+        host_ip: "127.0.0.3"
     # Restart Icinga Web container automatically since we have to wait for the database to be ready.
     # Please note that this needs a more sophisticated solution.
     restart: on-failure


### PR DESCRIPTION
## Summary
- use extended port mapping syntax for icinga2 and icingaweb

## Testing
- `docker-compose config` *(fails: services.icinga2.ports contains unsupported option: 'host_ip')*


------
https://chatgpt.com/codex/tasks/task_e_68acef16d568832cbead5b52fc146137