### PR TITLE
Remove obsolete version declaration from compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 x-icinga-db-web-config:
   &icinga-db-web-config
   icingaweb.modules.icingadb.config.icingadb.resource: icingadb


### PR DESCRIPTION
## Summary
- drop outdated `version` field from `docker-compose.yml`

## Testing
- `docker compose config` *(fails: command not found)*
- `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aceeda7900832cb64ca16cff2af2da