### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/05_docker_first_deploy.yml
+++ b/.github/workflows/05_docker_first_deploy.yml
@@ -1,4 +1,6 @@
 name: docker_first_deploy (smoke)
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/jiri001meitner/docker-compose-icinga/security/code-scanning/5](https://github.com/jiri001meitner/docker-compose-icinga/security/code-scanning/5)

To fix the issue, explicitly set a `permissions` block in the workflow, ideally at the root (top-level), so it applies to all jobs. Review the workflow content: none of the steps require write access to repository contents, issues, or pull requests; the jobs only run shell commands, inspect Docker containers, and clean up.  
Therefore, set `permissions: contents: read` at the top of the workflow, just below the workflow `name` field and before the `on:` block (as per best practice).  
No imports or further configuration is necessary.  
Only edit `.github/workflows/05_docker_first_deploy.yml`, adding the block:

```yaml
permissions:
  contents: read
```
after the workflow name.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
