### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/04_docker_compose_up_d.yml
+++ b/.github/workflows/04_docker_compose_up_d.yml
@@ -1,5 +1,8 @@
 name: Compose up (smoke)
 
+permissions:
+  contents: read
+
 on:
   push:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/jiri001meitner/docker-compose-icinga/security/code-scanning/3](https://github.com/jiri001meitner/docker-compose-icinga/security/code-scanning/3)

To fix this problem, you should add a `permissions` block to the workflow or to the job. Since this workflow does not interact with GitHub resources with write access (it does not create releases, push code, make issues, or modify pull requests), the minimal privilege required is `contents: read`. This block can be added at the top level (before `jobs:` line) to consistently apply least privilege to all jobs in this workflow. Specifically, insert the following block after the workflow name declaration (after line 1 and before `on:` on line 3):

```yaml
permissions:
  contents: read
```

No new imports, functions, or external dependencies are required; only a simple addition of static configuration in the YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
