### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/03_docker_compose_test_syntax.yml
+++ b/.github/workflows/03_docker_compose_test_syntax.yml
@@ -1,4 +1,6 @@
 name: Compose validate
+permissions:
+  contents: read
 on:
   push:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/jiri001meitner/docker-compose-icinga/security/code-scanning/4](https://github.com/jiri001meitner/docker-compose-icinga/security/code-scanning/4)

The best way to fix this problem is to add an explicit `permissions` block with minimal required scopes, before any jobs are defined (i.e. at the top/root of the YAML file), or within the `validate` job. In this workflow, the job only needs to access repository files read-only, so `contents: read` is sufficient. You should add this block immediately after the `name:` and before `on:`, or after `on:` and before `jobs:` (both are valid, though the first is recommended for clarity). No other permissions are needed. No existing functionality will be changed, and no new imports or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
