### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/01_shellcheck.yml
+++ b/.github/workflows/01_shellcheck.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   shellcheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/jiri001meitner/docker-compose-icinga/security/code-scanning/2](https://github.com/jiri001meitner/docker-compose-icinga/security/code-scanning/2)

To fix this problem, explicitly specify the least-privilege `permissions:` block at the root of the workflow YAML, above the `jobs:` key. Since the workflow only reads source files (with ShellCheck and `git ls-files`), only `contents: read` is needed. This restricts the GITHUB_TOKEN to only read repository contents for the entire workflow.

**How:**  
- Insert the block:
  ```yaml
  permissions:
    contents: read
  ```
  immediately after the `name` and `on` blocks, before `jobs:`.

**Where:**  
- In `.github/workflows/01_shellcheck.yml`, add `permissions:` right after the initial workflow metadata (ideally, after `on:` but before `jobs:`).

**What is needed:**  
- No new methods, imports, or definitions are required; only the YAML permissions key needs to be set.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
