### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/02_pylint.yml
+++ b/.github/workflows/02_pylint.yml
@@ -1,4 +1,6 @@
 name: Pylint
+permissions:
+  contents: read
 
 on: [push]
 


### PR DESCRIPTION
Potential fix for [https://github.com/jiri001meitner/docker-compose-icinga/security/code-scanning/1](https://github.com/jiri001meitner/docker-compose-icinga/security/code-scanning/1)

To fix the problem, add an explicit `permissions` block to the workflow with the least privileges required. Since the steps only need to check out code and run `pylint` for analysis, read-only repository contents permission is sufficient. The `permissions` block should be added at either the root of the workflow file (to apply to all jobs) or inside the `build` job (to apply only to it). The recommended minimal block to add is:

```yaml
permissions:
  contents: read
```

Insert this block immediately after the `name:` and before `on:` at the top of the file to apply it globally, which is best practice unless there's a specific need per-job. No imports or additional libraries are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
